### PR TITLE
アドオン名には Mozilla または Firefox の商標を含めることはできません。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# firefox-sidebar-html-capture
+# html-capture
 
 This is a tool that captures displayed web pages into text files.
 You can use it to debug dynamically changing web pages.
@@ -55,13 +55,13 @@ This manual can supprot English and Japanese.
 
 ## Limitation （制限）
 
-You can use only 1 tab when using firefox-sidebar-html-capture.
+You can use only 1 tab when using html-capture.
 
 本ツール利用時は、タブ１個のみで作業してください。
 
 ## Report issue （問題を見つけた場合）
 
-1. create Issue ticket in [this repository](https://github.com/stageleft/firefox-sidebar-html-capture).
+1. create Issue ticket in [this repository](https://github.com/stageleft/html-capture).
 2. mention to me in Twitter: [@elderalliance](https://twitter.com/elderalliance).
 
 GitHubでチケット切ってください。その後、私のTwitterアカウントまでお知らせください。

--- a/create_xpi.ps1
+++ b/create_xpi.ps1
@@ -1,12 +1,12 @@
-# Powershell script to create firefox-sidebar-html-capture.xpi
+# Powershell script to create html-capture.xpi
 
-if (Test-Path 'firefox-sidebar-html-capture.xpi' ){
-    Remove-Item 'firefox-sidebar-html-capture.xpi'
+if (Test-Path 'html-capture.xpi' ){
+    Remove-Item 'html-capture.xpi'
 }
-if (Test-Path 'firefox-sidebar-html-capture.zip' ){
-    Remove-Item  'firefox-sidebar-html-capture.zip'
+if (Test-Path 'html-capture.zip' ){
+    Remove-Item  'html-capture.zip'
 }
 
-Compress-Archive -Path 'src\*' -DestinationPath 'firefox-sidebar-html-capture.zip'
+Compress-Archive -Path 'src\*' -DestinationPath 'html-capture.zip'
 
-Rename-Item 'firefox-sidebar-html-capture.zip' 'firefox-sidebar-html-capture.xpi'
+Rename-Item 'html-capture.zip' 'html-capture.xpi'

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Firefox Sidebar HTML Capture",
+  "name": "HTML Capture",
   "version": "1.0",
 
   "description": "Realtime HTML Capture",
@@ -11,7 +11,7 @@
   },
 
   "sidebar_action": {
-    "default_title": "Firefox Sidebar HTML Capture",
+    "default_title": "HTML Capture",
     "default_panel": "sidebar.html",
     "default_icon": {
       "16": "16x16.png",
@@ -29,7 +29,7 @@
 
   "applications": {
     "gecko": {
-      "id": "firefox-sidebar-html-capture@elder-alliance.org"
+      "id": "html-capture@elder-alliance.org"
     }
   }
 }

--- a/src/sidebar.html
+++ b/src/sidebar.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Firefox Sidebar HTML Capture(Sidebar Interface)</title>
+  <title>HTML Capture</title>
   <link rel="stylesheet" type="text/css" href="sidebar.css">
 </head>
 <body>


### PR DESCRIPTION
Fixes #1